### PR TITLE
Full job not running on workflow dispatch fix

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,7 +27,6 @@ jobs:
     name: Smoke Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_smoke_only == 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -51,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     needs: smoke-test
-    if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_smoke_only == 'false'
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.run_smoke_only != 'true'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
- smoke tests will always run on workflow_dispatch
- full test will run on workflow_dispatch when run_smoke_only is set to false
- both will run on Merge Request events